### PR TITLE
Tidy up Museo font styles

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,11 +12,6 @@ const MyApp: React.FC<React.PropsWithChildren<AppProps>> = ({
     // @ts-expect-error acknowledged bug by Paste creators
     // https://github.com/twilio-labs/paste/issues/3239#issuecomment-1553613071
     <CustomizationProvider baseTheme="default" theme={CustomTheme}>
-      <style jsx global>{`
-        * {
-          font-family: "museosans";
-        }
-      `}</style>
       <Component {...pageProps} />
     </CustomizationProvider>
   );

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,34 +1,13 @@
 import { Html, Head, Main, NextScript } from "next/document";
-// import localFont from "@next/font/local";
-
-// const poppins = localFont({
-//   src: [
-//     {
-//       path: "../../public/fonts/Poppins-Regular.ttf",
-//       weight: "400",
-// style: "normal",
-//     },
-//     {
-//       path: "../../public/fonts/Poppins-Bold.ttf",
-//       weight: "700",
-//     },
-//   ],
-//   variable: "--font-poppins",
-// });
 
 const Document = (): JSX.Element => {
   return (
     <Html>
       <Head>
-        {/* <Head className={`${poppins.variable} font-sans`}> */}
         <link
           rel="preconnect"
           href="https://assets.twilio.com"
           crossOrigin=""
-        />
-        <link
-          rel="stylesheet"
-          href="https://assets.twilio.com/public_assets/paste-fonts/1.5.0/fonts.css"
         />
       </Head>
       <body>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -74,10 +74,7 @@ const Home: NextPage = () => {
           injures someone or damages their property.
         </Text>
         <FormControl>
-          <RadioGroup
-            legend="Address implementation"
-            name="address-implementation"
-          >
+          <RadioGroup legend="Please choose a cover" name="pl_cover_limit">
             <Radio value="2000000">£2,000,000</Radio>
             <Radio value="5000000">£5,000,000</Radio>
           </RadioGroup>

--- a/pages/themes/theme.json
+++ b/pages/themes/theme.json
@@ -246,13 +246,13 @@
     "colorBackgroundWeak": "rgb(249, 249, 250)"
   },
   "fonts": {
-    "fontFamilyCode": "'TwilioSansMono', Courier, monospace",
-    "fontFamilyDisplay": "'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-    "fontFamilyText": "'Inter var experimental', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-    "fontFamilyTextChineseSimplified": "'Inter var experimental', 'Inter var', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体, SimSun, sans-serif",
-    "fontFamilyTextChineseTraditional": "'Inter var experimental', 'Inter var', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑, 宋体, SimSun, sans-serif",
-    "fontFamilyTextJapanese": "'Inter var experimental', 'Inter var', Hiragino Sans, 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', 'メイリオ', Meiryo, Osaka, 'MS PGothic', sans-serif",
-    "fontFamilyTextKorean": "'Inter var experimental', 'Inter var', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑, 宋体, SimSun, sans-serif"
+    "fontFamilyCode": "Courier, monospace",
+    "fontFamilyDisplay": "museosans, Arial, sans-serif",
+    "fontFamilyText": "museosans, Arial, sans-serif",
+    "fontFamilyTextChineseSimplified": "'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体, SimSun, sans-serif",
+    "fontFamilyTextChineseTraditional": "'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑, 宋体, SimSun, sans-serif",
+    "fontFamilyTextJapanese": "Hiragino Sans, 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', 'メイリオ', Meiryo, Osaka, 'MS PGothic', sans-serif",
+    "fontFamilyTextKorean": "'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑, 宋体, SimSun, sans-serif"
   },
   "fontSizes": {
     "fontSize10": "0.625rem",


### PR DESCRIPTION
By deleting redundant overwrite code, as well as unnecessary default
Twilio font imports